### PR TITLE
use java_import instead import 

### DIFF
--- a/lib/yuicompressor/jruby.rb
+++ b/lib/yuicompressor/jruby.rb
@@ -7,10 +7,10 @@ module YUICompressor
 
   require JAR_FILE
 
-  import java.io.InputStreamReader
-  import java.io.OutputStreamWriter
-  import com.yahoo.platform.yui.compressor.JavaScriptCompressor
-  import com.yahoo.platform.yui.compressor.CssCompressor
+  java_import java.io.InputStreamReader
+  java_import java.io.OutputStreamWriter
+  java_import com.yahoo.platform.yui.compressor.JavaScriptCompressor
+  java_import com.yahoo.platform.yui.compressor.CssCompressor
 
   class ErrorReporter #:nodoc:
     def error(message, source_name, line, line_source, line_offset)


### PR DESCRIPTION
Use java_import instead import for importing java classes. 

There is known bug for import: http://jira.codehaus.org/browse/JRUBY-3171 and jruby >= 1.7.0 throws error on import usage...
