### PR TITLE
Add charset option and default it to utf8.

### DIFF
--- a/README
+++ b/README
@@ -51,6 +51,8 @@ When compressing CSS, the following option is available:
                     single line of compressed code. Defaults to no maximum
                     length. If set to 0 each line will be the minimum length
                     possible.
+    :charset        Sests the carset in which to read the input file. Passed
+                    through to the YUICompressor Java library. Default: utf8
 
 When compressing JavaScript, these additional options are available:
 

--- a/lib/yuicompressor.rb
+++ b/lib/yuicompressor.rb
@@ -18,6 +18,7 @@ module YUICompressor
   #                   single line of compressed code. Defaults to no maximum
   #                   length. If set to 0 each line will be the minimum length
   #                   possible.
+  # +:charset+::      Charset. Default is utf8.
   def compress_css(stream_or_string, options={}, &block)
     compress(stream_or_string, options.merge(:type => 'css'), &block)
   end
@@ -35,19 +36,21 @@ module YUICompressor
   #                           all semicolons in the code. Defaults to +false+.
   # +:optimize+::     Should be +true+ if the compressor should enable all
   #                   micro optimizations. Defaults to +true+.
+  # +:charset+::      Charset. Default is utf8.
   def compress_js(stream_or_string, options={}, &block)
     compress(stream_or_string, options.merge(:type => 'js'), &block)
   end
 
   def default_css_options #:nodoc:
-    { :line_break => nil }
+    { :line_break => nil, :charset => 'utf8' }
   end
 
   def default_js_options #:nodoc:
     default_css_options.merge(
       :munge => false,
       :preserve_semicolons => false,
-      :optimize => true
+      :optimize => true,
+      :charset => 'utf8'
     )
   end
 

--- a/lib/yuicompressor/shell.rb
+++ b/lib/yuicompressor/shell.rb
@@ -13,6 +13,7 @@ module YUICompressor
     args = []
     args.concat(['--type', options[:type].to_s]) if options[:type]
     args.concat(['--line-break', options[:line_break].to_s]) if options[:line_break]
+    args.concat(['--charset', options[:charset].to_s]) if options[:charset]
 
     if options[:type].to_s == 'js'
       args << '--nomunge' unless options[:munge]

--- a/test/css_test.rb
+++ b/test/css_test.rb
@@ -10,7 +10,7 @@ class CSSTest < Test::Unit::TestCase
     if jruby?
       assert_equal([-1], args)
     else
-      assert_equal([], args)
+      assert_equal(['--charset', 'utf8'], args)
     end
   end
 

--- a/test/js_test.rb
+++ b/test/js_test.rb
@@ -10,7 +10,7 @@ class JSTest < Test::Unit::TestCase
     if jruby?
       assert_equal([-1], args)
     else
-      assert_equal([], args)
+      assert_equal(['--charset', 'utf8'], args)
     end
   end
 


### PR DESCRIPTION
The option exists in the Java library, but was not exposed through the Ruby interface. Also, YUI defaults to utf8 since version 2.4.5, so I made this default explicit in the Ruby wrapper as well.
