### PR TITLE
Make stream reading UTF-8 safe

### DIFF
--- a/lib/yuicompressor/shell.rb
+++ b/lib/yuicompressor/shell.rb
@@ -54,9 +54,7 @@ module YUICompressor
 
     Open3.popen3(command.join(' ')) do |input, output, stderr|
       begin
-        while buffer = stream.read(4096)
-          input.write(buffer)
-        end
+        input.write(stream.read)
         input.close_write
 
         output.read

--- a/yuicompressor.gemspec
+++ b/yuicompressor.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = 'yuicompressor'
-  s.version = '1.3.0'
-  s.date = '2014-01-22'
+  s.version = '1.3.1'
+  s.date = '2014-01-29'
 
   s.summary = 'A YUI JavaScript and CSS compressor for Ruby and JRuby'
   s.description = 'A YUI JavaScript and CSS compressor for Ruby and JRuby'


### PR DESCRIPTION
IO#read(length) is not UTF-8 safe. It can truncate UTF-8 characters and lead to errors in the compressor like: Compression failed: "\xE2" from ASCII-8BIT to UTF-8

I removed the length parameters which causes Ruby to read the entire stream in one go. This may require more system resources for very large CSS/JS files
but will not fail for UTF-8 files.
