### PR TITLE
Errors in compressor not raised on the Ruby side.

### DIFF
--- a/lib/yuicompressor.rb
+++ b/lib/yuicompressor.rb
@@ -64,6 +64,14 @@ module YUICompressor
     end
   end
 
+  def stringify(stream_or_string) #:nodoc:
+    case stream_or_string
+      when IO then stream_or_string.read
+      when String then stream_or_string
+      else raise ArgumentError, 'Stream or string required'
+    end
+  end
+
   # If we're on JRuby we can use the YUI Compressor Java classes directly. This
   # gives a huge speed boost. Otherwise we need to make a system call to the
   # Java interpreter and stream IO to/from the shell.

--- a/test/js_test.rb
+++ b/test/js_test.rb
@@ -86,4 +86,10 @@ CODE
   def test_large_stream
     assert compress_js(File.new(File.expand_path('../_files/jquery-1.4.2.js', __FILE__), 'r'))
   end
+
+  def test_error_reporting
+    assert_raises RuntimeError do
+      compress_js('function() {;')  # syntax error
+    end
+  end
 end

--- a/yuicompressor.gemspec
+++ b/yuicompressor.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = 'yuicompressor'
-  s.version = '1.3.2'
-  s.date = '2014-01-29'
+  s.version = '1.3.3'
+  s.date = '2014-02-28'
 
   s.summary = 'A YUI JavaScript and CSS compressor for Ruby and JRuby'
   s.description = 'A YUI JavaScript and CSS compressor for Ruby and JRuby'


### PR DESCRIPTION
 If the Java yuicompressor reported an error, it would not raise an exception on the Ruby side. This is because the Open3.popen3 doesn't actually raise an exception in the block. Also added test coverage for the error case.

Fixed this with using Open3.capture3 instead which reports job status explicitly.
Open3.capture3 takes a string as input and returns a string. Added `stringify` method to convert strings.

(Side Note: If using streams, all streams should probably be opened in "binary" mode explicitly to avoid
further UTF-8 gliches. This might still be a problem in the jRuby code path.)

Bumped version to 1.3.3
